### PR TITLE
Catch MediaPlayer exception

### DIFF
--- a/src/main/java/nl/delftelectronics/spaceinvaders/core/Audio.java
+++ b/src/main/java/nl/delftelectronics/spaceinvaders/core/Audio.java
@@ -1,6 +1,7 @@
 package nl.delftelectronics.spaceinvaders.core;
 
 import javafx.scene.media.Media;
+import javafx.scene.media.MediaException;
 import javafx.scene.media.MediaPlayer;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -40,10 +41,14 @@ public final class Audio {
      * @param filename filename of the sound.
      */
     private static void playSound(final String filename) {
-        Media media = new Media(Audio.class.getResource(filename).toString());
-        MediaPlayer mp = new MediaPlayer(media);
-        mp.play();
-        // Add Media Player to Collection so that it doesn't get garbage collected.
-        mps.add(mp);
+        try {
+            Media media = new Media(Audio.class.getResource(filename).toString());
+            MediaPlayer mp = new MediaPlayer(media);
+            mp.play();
+            // Add Media Player to Collection so that it doesn't get garbage collected.
+            mps.add(mp);
+        } catch (MediaException e) {
+            System.err.println("Could not instantiate Media Player");
+        }
     }
 }

--- a/src/main/java/nl/delftelectronics/spaceinvaders/core/Audio.java
+++ b/src/main/java/nl/delftelectronics/spaceinvaders/core/Audio.java
@@ -48,7 +48,7 @@ public final class Audio {
             // Add Media Player to Collection so that it doesn't get garbage collected.
             mps.add(mp);
         } catch (MediaException e) {
-            System.err.println("Could not instantiate Media Player");
+            Logger.warning("Could not instantiate Media Player");
         }
     }
 }


### PR DESCRIPTION
On some platforms, MediaPlayer throws an exception when multiple sounds
are played. This does not affect the functionality of the game, so we
can just catch the exception and do nothing to handle it (as there is no
fix/workaround).

<bug
